### PR TITLE
MongoHelper: Allow indexing on immutable properties.

### DIFF
--- a/src/main/kotlin/com/moshbit/katerbase/MongoHelper.kt
+++ b/src/main/kotlin/com/moshbit/katerbase/MongoHelper.kt
@@ -8,10 +8,7 @@ import org.bson.Document
 import org.bson.conversions.Bson
 import java.util.*
 import java.util.regex.Pattern
-import kotlin.reflect.KClass
-import kotlin.reflect.KMutableProperty1
-import kotlin.reflect.KParameter
-import kotlin.reflect.KTypeParameter
+import kotlin.reflect.*
 
 abstract class MongoEntry {
   fun toBSONDocument(): Document = JsonHandler.toBsonDocument(this)
@@ -88,12 +85,12 @@ fun <Value> MongoEntryField<Value>.toMongoField() = MongoField(name)
 /**
  * Use this if you want to access a subdocument's field
  */
-fun <Class, Value> MongoEntryField<out Any>.child(property: KMutableProperty1<Class, Value>): MongoEntryField<Value> {
+fun <Class, Value> MongoEntryField<out Any>.child(property: KProperty1<Class, Value>): MongoEntryField<Value> {
   return this.toMongoField().extend(property.name).toProperty()
 }
 
 @JvmName("childOnNullable")
-fun <Class, Value> NullableMongoEntryField<out Any>.child(property: KMutableProperty1<Class, Value>): MongoEntryField<Value> {
+fun <Class, Value> NullableMongoEntryField<out Any>.child(property: KProperty1<Class, Value>): MongoEntryField<Value> {
   return this.toMongoField().extend(property.name).toProperty()
 }
 


### PR DESCRIPTION
Case: using immutable properties ('val') for all kinds of DTOs is a common trend not only in Kotlin, but in general in the software world.
For reasons unknown, Katerbase often forces the user to use entities with mutable properties, even if mutable properties in the Kotlin typing system are in fact a subtype of immutable properties.
This PR allows the use of immutable properties for indexing.